### PR TITLE
Add n8n workflow for chat tools agent

### DIFF
--- a/_posts/2024-06-05-n8n-tools-agent-gpt4-mini-postgres.markdown
+++ b/_posts/2024-06-05-n8n-tools-agent-gpt4-mini-postgres.markdown
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "n8n Chat Tools Agent with Postgres Memory"
+date: 2024-06-05 00:00:00 -0000
+categories: n8n workflow
+---
+
+This post shows a minimal n8n workflow that connects a basic chat trigger to a
+Tools Agent powered by the `gpt-4.1-mini` model. Conversation memory is stored in
+PostgreSQL so the agent can recall previous interactions.
+
+Download the workflow JSON here:
+[chat-to-tools-agent-postgres.json](/workflows/chat-to-tools-agent-postgres.json)
+
+The workflow includes two nodes:
+
+1. **Chat Trigger** — A Webhook node listening for `POST` requests on the path
+   `chat-trigger`.
+2. **Tools Agent** — Uses the OpenAI node to run the `gpt-4.1-mini` model with
+   the memory strategy set to Postgres.
+
+When a request hits the Webhook, the chat message is forwarded to the Tools
+Agent. The agent processes the input with GPT‑4.1‑mini and keeps context in a
+Postgres-backed memory.
+
+Import the JSON file in n8n to try it out.

--- a/workflows/chat-to-tools-agent-postgres.json
+++ b/workflows/chat-to-tools-agent-postgres.json
@@ -1,0 +1,50 @@
+{
+  "name": "Chat Tools Agent with Memory",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "chat-trigger"
+      },
+      "id": "1",
+      "name": "Chat Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [260, 300]
+    },
+    {
+      "parameters": {
+        "operation": "complete",
+        "resource": "chat",
+        "model": "gpt-4.1-mini",
+        "memory": "postgres"
+      },
+      "id": "2",
+      "name": "Tools Agent",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 1,
+      "position": [480, 300],
+      "credentials": {
+        "openAiApi": {
+          "id": "{{OPENAI_CREDENTIAL_ID}}",
+          "name": "OpenAI Account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Chat Trigger": {
+      "main": [
+        [
+          {
+            "node": "Tools Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {}
+}


### PR DESCRIPTION
## Summary
- add example n8n workflow JSON that triggers a Tools Agent using gpt‑4.1-mini with Postgres memory
- document the workflow in a new blog post

## Testing
- `python - <<'PY'
import json
print(json.load(open('workflows/chat-to-tools-agent-postgres.json')))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6841a93fb1308329b5a5d561dd78400e